### PR TITLE
fix docker dev setup and add contributor docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Exclude node_modules and build output to speed up docker build
+node_modules
+.next
+
+# Exclude git metadata and local files
+.git
+.gitignore
+
+# Exclude logs and editor settings
+*.log
+.env.local
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing Guide
+
+Thanks for your interest in helping with this project!
+
+## Development Environment
+
+### Local Setup
+1. Install Node.js 20+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+### Docker Setup
+1. Build and start using Docker Compose:
+   ```bash
+   docker compose up --build
+   ```
+   The compose file uses the `deps` build stage so all
+   development dependencies (including `next`) are available.
+2. The app will be available at [http://localhost:3000](http://localhost:3000).
+
+## Code Quality
+- Run linting before submitting a pull request:
+  ```bash
+  npm run lint
+  ```
+- Ensure the project builds:
+  ```bash
+  npm run build
+  ```
+
+## Submitting Changes
+1. Fork the repository and create a branch from `main`.
+2. Commit your changes with descriptive messages.
+3. Open a pull request and describe the motivation and testing.
+
+We appreciate your contributions!

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ podman run -p 80:80 personal-manager-frontend
 
 ## 🤝 Contributing
 
+For detailed setup steps and contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ### Development Workflow
 1. Clone the repository with submodules
 2. Create a feature branch from `main`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,9 @@ version: "3.8"
 services:
   frontend:
     user: root
-    build: .
+    build:
+      context: .
+      target: deps
     command: npm run dev
     volumes:
       - .:/app:z


### PR DESCRIPTION
## Summary
- ensure `next` is available in dev containers by building from the `deps` stage
- ignore unnecessary files with `.dockerignore` for faster Docker builds
- add contributor guide and link from README

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689f99a318ac8329a7f6ed86eea27505