### PR TITLE
refactor: modernize theme and navigation

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -1,3 +1,5 @@
+@use './_colors.scss' as c;
+
 :root {
   --nav-h: 35px; /* your navbar height */
 }
@@ -11,6 +13,8 @@ body {
     sans-serif;
   margin: 0;
   padding: 0;
+  background: linear-gradient(135deg, c.$primary-green 0%, c.$secondary-green 100%);
+  color: c.$primary-text;
 }
 
 *,
@@ -30,5 +34,31 @@ h2,
 .handwritten {
   /* Shadows for decorative bits */
   font-family: var(--font-shadows), var(--font-patrick), system-ui, sans-serif;
+}
+
+/* Global button styling */
+button {
+  background-color: c.$accent-green;
+  color: c.$dark-green;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background-color: c.$light-green;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  }
+
+  &:disabled {
+    background-color: c.$muted-text;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+  }
 }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,18 +1,26 @@
-// components/Button.tsx
+import styles from './styles/Button.module.scss';
+
 type ButtonProps = {
   text: string;
-  onClick?: () => void;               // now optional
-  type?: "button" | "submit" | "reset"; // new
+  onClick?: () => void;
+  type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
+  className?: string;
 };
 
 const Button = ({
   text,
   onClick,
-  type = "button",
+  type = 'button',
   disabled = false,
+  className = '',
 }: ButtonProps) => (
-  <button type={type} onClick={onClick} disabled={disabled}>
+  <button
+    type={type}
+    onClick={onClick}
+    disabled={disabled}
+    className={`${styles.button} ${className}`.trim()}
+  >
     {text}
   </button>
 );

--- a/src/components/styles/Button.module.scss
+++ b/src/components/styles/Button.module.scss
@@ -1,0 +1,26 @@
+@use "../../app/_colors.scss" as c;
+
+.button {
+  background-color: c.$accent-green;
+  color: c.$dark-green;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background-color: c.$light-green;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  }
+
+  &:disabled {
+    background-color: c.$muted-text;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+  }
+}

--- a/src/components/styles/Navbar.module.scss
+++ b/src/components/styles/Navbar.module.scss
@@ -1,3 +1,5 @@
+@use "../../app/_colors.scss" as c;
+
 .navbar {
   position: fixed;
   top: 0;
@@ -6,13 +8,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
-  background-color: rgba(25, 50, 40, 0.9);
+  padding: 0.5rem 2rem;
+  background: linear-gradient(90deg, c.$primary-green, c.$logo-teal-dark);
   backdrop-filter: blur(10px);
-  color: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  color: c.$primary-text;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   z-index: 1000;
-  height: var(--nav-h); 
+  height: var(--nav-h);
 }
 
 .leftSection {
@@ -36,7 +38,7 @@
     display: block;
     height: 2px;
     width: 100%;
-    background-color: #9FBE5A;
+    background-color: c.$accent-green;
     transition: all 0.3s ease;
   }
   
@@ -46,8 +48,9 @@
 }
 
 .title {
-  font-size: 28px;
-  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: c.$accent-green;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -69,46 +72,50 @@
 }
 
 .username {
-  font-size: 22px;
+  font-size: 1.2rem;
   font-weight: 600;
-  color: #9FBE5A;
+  color: c.$accent-green;
 }
 
 .authButton {
-  background-color: #9FBE5A;
-  color: #1a2e29;
+  background-color: c.$accent-green;
+  color: c.$dark-green;
   border: none;
-  border-radius: 20px;
-  padding: 8px 16px;
-  font-size: 22px;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 1rem;
   cursor: pointer;
-  transition: all 0.3s ease;
-  
+  transition: background-color 0.3s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+
   &:hover {
-    background-color: #b5d772;
-    transform: scale(1.05);
+    background-color: c.$light-green;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
   }
 }
 
 .accountButton {
-  background-color: #4a6f82;
-  color: white;
+  background-color: c.$logo-teal;
+  color: c.$primary-text;
   border: none;
-  border-radius: 20px;
-  padding: 8px 16px;
-  font-size: 16px;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 1rem;
   cursor: pointer;
-  transition: all 0.3s ease;
-  
+  transition: background-color 0.3s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+
   &:hover {
-    background-color: #5a7a8f;
-    transform: scale(1.05);
+    background-color: c.$logo-teal-light;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
   }
 }
 
 .loading {
   font-size: 16px;
-  color: #9FBE5A;
+  color: c.$accent-green;
   animation: pulse 1.5s infinite;
 }
 
@@ -136,12 +143,12 @@
   .username {
     font-size: 20px;
     font-weight: 60;
-    color: #9FBE5A;
+    color: c.$accent-green;
   }
   
   .menuIcon {
     font-size: 12px;
-    color: #9FBE5A;
+    color: c.$accent-green;
     transition: transform 0.3s ease;
   }
 }


### PR DESCRIPTION
## Summary
- add global gradient theme and base button styling
- create reusable Button styles and hook up component
- refresh navbar colors and button styles for a cleaner look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a392416068832992bc3f24aa1d5222