### PR TITLE
Refine navbar sizing and task mobile layout

### DIFF
--- a/src/app/_colors.scss
+++ b/src/app/_colors.scss
@@ -5,6 +5,7 @@ $secondary-green: #183619;
 $accent-green: #9fbe5a;
 $light-green: #b5d772;
 $dark-green: #2f4f2f;
+$darkest-green: #0a0f0d;
 
 $logo-teal: #3cbccf;
 $logo-teal-light: color.scale($logo-teal, $lightness: 10%);

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -1,7 +1,14 @@
 @use './_colors.scss' as c;
 
+
 :root {
-  --nav-h: 35px; /* your navbar height */
+  --nav-h: 60px; /* default navbar height for mobile */
+}
+
+@media (min-width: 768px) {
+  :root {
+    --nav-h: 90px; /* taller navbar on larger screens */
+  }
 }
 
 html,
@@ -13,7 +20,11 @@ body {
     sans-serif;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, c.$primary-green 0%, c.$secondary-green 100%);
+  background: linear-gradient(
+    135deg,
+    c.$secondary-green 0%,
+    c.$darkest-green 100%
+  );
   color: c.$primary-text;
 }
 

--- a/src/app/personal-manager/tasks/page.module.scss
+++ b/src/app/personal-manager/tasks/page.module.scss
@@ -291,3 +291,30 @@ $line-height: 40px;
     transform: translateY(0);
   }
 }
+
+@media (max-width: 768px) {
+  .page {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .formPaper {
+    width: 100%;
+    margin: 0;
+    border-left: none;
+
+    fieldset {
+      min-height: 400px;
+      padding: 20px 10px 0;
+    }
+  }
+
+  .dangerZoneContainer {
+    position: static;
+    width: 100%;
+    max-width: 250px;
+    margin: 20px auto 0;
+    right: auto;
+    top: auto;
+  }
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,7 +16,7 @@ const Navbar = () => {
 
   useEffect(() => {
     const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
+      setIsMobile(window.innerWidth <= 1024);
     };
 
     checkMobile();
@@ -57,7 +57,7 @@ const Navbar = () => {
             <span></span>
           </button>
         )}
-        <div className={styles.title}>Sarkis.dev</div>
+        <div className={`${styles.title} brand-title`}>Sarkis.dev</div>
       </div>
 
       <div className={styles.authSection}>

--- a/src/components/styles/Navbar.module.scss
+++ b/src/components/styles/Navbar.module.scss
@@ -8,13 +8,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 2rem;
-  background: linear-gradient(90deg, c.$primary-green, c.$logo-teal-dark);
+  padding: 0 2rem;
+  background: linear-gradient(90deg, c.$secondary-green, c.$dark-green);
   backdrop-filter: blur(10px);
   color: c.$primary-text;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   z-index: 1000;
   height: var(--nav-h);
+  font-family: var(--font-patrick), system-ui, -apple-system, Segoe UI, Roboto,
+    sans-serif;
 }
 
 .leftSection {
@@ -54,6 +56,12 @@
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
 }
 
+@media (min-width: 768px) {
+  .title {
+    font-size: 2rem;
+  }
+}
+
 .authSection {
   display: flex;
   align-items: center;
@@ -87,6 +95,9 @@
   cursor: pointer;
   transition: background-color 0.3s ease, transform 0.2s ease,
     box-shadow 0.2s ease;
+  height: calc(var(--nav-h) - 20px);
+  display: flex;
+  align-items: center;
 
   &:hover {
     background-color: c.$light-green;
@@ -105,6 +116,9 @@
   cursor: pointer;
   transition: background-color 0.3s ease, transform 0.2s ease,
     box-shadow 0.2s ease;
+  height: calc(var(--nav-h) - 20px);
+  display: flex;
+  align-items: center;
 
   &:hover {
     background-color: c.$logo-teal-light;

--- a/src/components/tasks/styles/SideBarTasks.module.scss
+++ b/src/components/tasks/styles/SideBarTasks.module.scss
@@ -51,3 +51,25 @@
         }
     }
 }
+
+@media (max-width: 768px) {
+  .sideBar {
+    max-width: none;
+    width: 100%;
+    margin: 0;
+    padding-top: 20px;
+
+    div {
+      flex-direction: row;
+      justify-content: space-around;
+      border-radius: 0;
+      transform: none;
+
+      button {
+        margin: 0;
+        font: 20px "Shadows Into Light", cursive;
+        padding: 10px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enlarge global navbar height and size auth buttons to fit it
- reflow tasks page and sidebar on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive setup prompt, no lint executed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a397cbe24c832992a14c02b8ebab82