### PR TITLE
Fix auth flicker and token refresh issues

### DIFF
--- a/src/app/personal-manager/layout.tsx
+++ b/src/app/personal-manager/layout.tsx
@@ -3,6 +3,7 @@
 import Navbar from "@/components/Navbar";
 import PersonalManagerSidebar from "@/components/personal-manager/Sidebar";
 import { AuthProvider } from "@/context/AuthContext";
+import AuthRoutes from "@/components/protected-routes/AuthRoutes";
 
 export default function PersonalManagerLayout({
   children,
@@ -19,9 +20,11 @@ export default function PersonalManagerLayout({
       }}
     >
       <AuthProvider>
-        <Navbar />
+        <AuthRoutes>
+          <Navbar />
 
-        <PersonalManagerSidebar>{children}</PersonalManagerSidebar>
+          <PersonalManagerSidebar>{children}</PersonalManagerSidebar>
+        </AuthRoutes>
       </AuthProvider>
     </main>
   );

--- a/src/app/personal-manager/page.tsx
+++ b/src/app/personal-manager/page.tsx
@@ -1,40 +1,37 @@
 "use client";
 
-import AuthRoutes from "@/components/protected-routes/AuthRoutes";
 import styles from "./page.module.scss";
 
 export default function PersonalManagerPage() {
   return (
-    <AuthRoutes>
-      <div className={styles.welcomeContainer}>
-        <div className={styles.welcomeContent}>
-          <h1>Welcome to Personal Manager</h1>
-          <p>Choose a service from the sidebar to get started:</p>
+    <div className={styles.welcomeContainer}>
+      <div className={styles.welcomeContent}>
+        <h1>Welcome to Personal Manager</h1>
+        <p>Choose a service from the sidebar to get started:</p>
 
-          <div className={styles.serviceCards}>
-            <div className={styles.card}>
-              <div className={styles.cardIcon}>📋</div>
-              <h3>Tasks</h3>
-              <p>Manage your daily tasks and projects</p>
-            </div>
+        <div className={styles.serviceCards}>
+          <div className={styles.card}>
+            <div className={styles.cardIcon}>📋</div>
+            <h3>Tasks</h3>
+            <p>Manage your daily tasks and projects</p>
+          </div>
 
-            <div className={styles.card}>
-              <div className={styles.cardIcon}>📅</div>
-              <h3>Calendar</h3>
-              <p>Plan and schedule your activities</p>
-            </div>
+          <div className={styles.card}>
+            <div className={styles.cardIcon}>📅</div>
+            <h3>Calendar</h3>
+            <p>Plan and schedule your activities</p>
+          </div>
 
-            <div className={styles.card}>
-              <div className={styles.cardIcon}>📂</div>
-              <h3>Projects</h3>
-              <p>
-                Track and categorize your professional, financial, educational &
-                other projects
-              </p>
-            </div>
+          <div className={styles.card}>
+            <div className={styles.cardIcon}>📂</div>
+            <h3>Projects</h3>
+            <p>
+              Track and categorize your professional, financial, educational &
+              other projects
+            </p>
           </div>
         </div>
       </div>
-    </AuthRoutes>
+    </div>
   );
 }

--- a/src/app/personal-manager/projects/create/page.tsx
+++ b/src/app/personal-manager/projects/create/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/components/Button";
-import AuthRoutes from "@/components/protected-routes/AuthRoutes";
 import {
   createProfessionalProject,
   CreateProfessionalProjectRequest,
@@ -11,11 +10,7 @@ import {
 import styles from "./page.module.scss";
 
 export default function CreateProjectPage() {
-  return (
-    <AuthRoutes>
-      <CreateProjectForm />
-    </AuthRoutes>
-  );
+  return <CreateProjectForm />;
 }
 
 function CreateProjectForm() {

--- a/src/app/personal-manager/projects/professional/page.tsx
+++ b/src/app/personal-manager/projects/professional/page.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import ProjectsList from "@/components/projects/professional/ProjectProfessionalList";
-import SelectedProject from "@/components/projects/professional/SelectedProjectProfessional";
 import DeleteConfirmation from "@/components/projects/professional/DeleteConfirmation";
 import PaginationControls from "@/components/projects/professional/PaginationControlsProfessional";
 import Button from "@/components/Button";
@@ -17,17 +15,14 @@ import {
   UpdateProfessionalProjectRequest,
 } from "@/services/projects/professional/projects";
 import styles from "./page.module.scss";
-import AuthRoutes from "@/components/protected-routes/AuthRoutes";
 import ProjectsProfessionalList from "@/components/projects/professional/ProjectProfessionalList";
 import SelectedProjectProfessional from "@/components/projects/professional/SelectedProjectProfessional";
 
 export default function ProjectsPage() {
   return (
-    <AuthRoutes>
-      <Suspense fallback={<p>Loading...</p>}>
-        <ProjectsPageContent />
-      </Suspense>
-    </AuthRoutes>
+    <Suspense fallback={<p>Loading...</p>}>
+      <ProjectsPageContent />
+    </Suspense>
   );
 }
 

--- a/src/app/personal-manager/tasks/page.tsx
+++ b/src/app/personal-manager/tasks/page.tsx
@@ -18,15 +18,11 @@ import SideBarTasks from "@/components/tasks/SideBar";
 import DeleteConfirmation from "@/components/tasks/DeleteConfirmation";
 import { useSearchParams } from "next/navigation";
 import Button from "@/components/Button";
-import AuthRoutes from "@/components/protected-routes/AuthRoutes";
-
 export default function Tasks() {
   return (
-    <AuthRoutes>
-      <Suspense fallback={<p>Loading...</p>}>
-        <TasksContent />
-      </Suspense>
-    </AuthRoutes>
+    <Suspense fallback={<p>Loading...</p>}>
+      <TasksContent />
+    </Suspense>
   );
 }
 

--- a/src/services/projects/professional/projects.ts
+++ b/src/services/projects/professional/projects.ts
@@ -1,4 +1,4 @@
-import { getToken, isAuthenticated } from "@/services/auth/keycloak";
+import { getToken, updateToken } from "@/services/auth/keycloak";
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_PROJECT_PROFESSIONAL_SERVICE_URL ||
@@ -67,14 +67,19 @@ export interface PaginatedProjectsResponse {
 /**
  * Get authentication headers for API requests
  */
-const getHeaders = (): Record<string, string> => {
+const getHeaders = async (): Promise<Record<string, string>> => {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
 
   if (typeof window !== "undefined") {
-    const token = getToken();
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    try {
+      await updateToken(5);
+      const token = getToken();
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+    } catch (error) {
+      console.error("Error getting auth token:", error);
+    }
   }
 
   return headers;
@@ -100,7 +105,7 @@ export const getProfessionalProjects = async (
     const url = `${ENDPOINT}?page=${page}&pageSize=${pageSize}`;
     const response = await fetch(url, {
       method: "GET",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       signal: t.signal,
     });
     t.clear();
@@ -129,7 +134,7 @@ export const getProfessionalProjectById = async (
     const t = withTimeout(15000);
     const response = await fetch(`${ENDPOINT}/id/${id}`, {
       method: "GET",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       signal: t.signal,
     });
     t.clear();
@@ -156,7 +161,7 @@ export const createProfessionalProject = async (
     const t = withTimeout(15000);
     const response = await fetch(`${ENDPOINT}`, {
       method: "POST",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(project),
       signal: t.signal,
     });
@@ -188,7 +193,7 @@ export const updateProfessionalProject = async (
     const t = withTimeout(15000);
     const response = await fetch(`${ENDPOINT}/id/${id}`, {
       method: "PUT",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(project),
       signal: t.signal,
     });
@@ -215,7 +220,7 @@ export const deleteProfessionalProject = async (id: string): Promise<void> => {
     const t = withTimeout(15000);
     const response = await fetch(`${ENDPOINT}/id/${id}`, {
       method: "DELETE",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       signal: t.signal,
     });
     t.clear();
@@ -238,7 +243,7 @@ export const deleteSelectedProjects = async (projectIds: string[]): Promise<void
   try {
     const response = await fetch(`${ENDPOINT}/delete-selected`, {
       method: "POST",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(projectIds),
       signal: t.signal,
     });
@@ -262,7 +267,7 @@ export const getMyAssignments = async (): Promise<ProjectAssignment[]> => {
     const t = withTimeout(15000);
     const response = await fetch(`${ENDPOINT}/mine`, {
       method: "GET",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       signal: t.signal,
     });
     console.log(response)
@@ -304,7 +309,7 @@ export const createProjectAssignment = async (
   try {
     const res = await fetch(`${ENDPOINT}/id/${projectId}/freelance`, {
       method: "POST",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify({ costPerHour, description }),
       signal: t.signal,
     });

--- a/src/services/projects/sessions/sessions.ts
+++ b/src/services/projects/sessions/sessions.ts
@@ -1,4 +1,4 @@
-import { getToken, isAuthenticated } from "@/services/auth/keycloak";
+import { getToken, isAuthenticated, updateToken } from "@/services/auth/keycloak";
 
 const ENDPOINT =
   process.env.NEXT_PUBLIC_PROJECT_PROFESSIONAL_SERVICE_URL ||
@@ -66,9 +66,10 @@ const getHeaders = async (): Promise<HeadersInit> => {
     "Content-Type": "application/json",
   };
 
-  if (isAuthenticated() && getToken) {
+  if (isAuthenticated()) {
     try {
-      const token = await getToken();
+      await updateToken(5);
+      const token = getToken();
       if (token) headers["Authorization"] = `Bearer ${token}`;
     } catch (err) {
       console.error("sessions.ts:getHeaders -> token error:", err);

--- a/src/services/tasks/tasks.ts
+++ b/src/services/tasks/tasks.ts
@@ -21,7 +21,7 @@ export interface PaginatedTasksResponse {
   total: number;
 }
 
-const getHeaders = (): Record<string, string> => {
+const getHeaders = async (): Promise<Record<string, string>> => {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
@@ -29,7 +29,10 @@ const getHeaders = (): Record<string, string> => {
   // Add authorization if available
   if (typeof window !== "undefined") {
     try {
-      const { getToken } = require("@/services/auth/keycloak");
+      const { getToken, updateToken } = require("@/services/auth/keycloak");
+      if (updateToken) {
+        await updateToken(5);
+      }
       const token = getToken();
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
@@ -70,7 +73,7 @@ export const getAllTasks = async (
       `${ENDPOINT}/tasks?page=${page}&pageSize=${pageSize}`,
       {
         method: "GET",
-        headers: getHeaders(),
+        headers: await getHeaders(),
       }
     );
 
@@ -99,7 +102,7 @@ export const getCompletedTasks = async (
       `${ENDPOINT}/tasks/completed?page=${page}&pageSize=${pageSize}`,
       {
         method: "GET",
-        headers: getHeaders(),
+        headers: await getHeaders(),
       }
     );
 
@@ -128,7 +131,7 @@ export const getNonCompletedTasks = async (
       `${ENDPOINT}/tasks/active?page=${page}&pageSize=${pageSize}`,
       {
         method: "GET",
-        headers: getHeaders(),
+        headers: await getHeaders(),
       }
     );
 
@@ -152,7 +155,7 @@ export const getTaskById = async (id: string): Promise<Task> => {
   try {
     const response = await fetch(`${ENDPOINT}/tasks/${id}`, {
       method: "GET",
-      headers: getHeaders(),
+      headers: await getHeaders(),
     });
 
     if (!response.ok) {
@@ -175,7 +178,7 @@ export const createTask = async (task: Task): Promise<Task> => {
   try {
     const response = await fetch(`${ENDPOINT}/tasks`, {
       method: "POST",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(task),
     });
 
@@ -204,7 +207,7 @@ export const updateTask = async (
   try {
     const response = await fetch(`${ENDPOINT}/tasks/update/${id}`, {
       method: "PATCH",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(task),
     });
 
@@ -227,7 +230,7 @@ export const deleteSelectedTasks = async (taskIds: string[]): Promise<void> => {
   try {
     const response = await fetch(`${ENDPOINT}/tasks/delete-selected`, {
       method: "POST",
-      headers: getHeaders(),
+      headers: await getHeaders(),
       body: JSON.stringify(taskIds),
     });
 
@@ -248,7 +251,7 @@ export const deleteAllCompletedTasks = async (): Promise<void> => {
   try {
     const response = await fetch(`${ENDPOINT}/tasks/delete-completed`, {
       method: "DELETE",
-      headers: getHeaders(),
+      headers: await getHeaders(),
     });
 
     if (!response.ok) {
@@ -268,7 +271,7 @@ export const deleteAllNonCompletedTasks = async (): Promise<void> => {
   try {
     const response = await fetch(`${ENDPOINT}/tasks/delete-non-completed`, {
       method: "DELETE",
-      headers: getHeaders(),
+      headers: await getHeaders(),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Wrap Personal Manager layout with AuthRoutes so unauthorized users are blocked before content renders
- Remove per-page AuthRoutes and refresh Keycloak token for API requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5292d6884832985f3ab2ee0796934